### PR TITLE
Fix 'Vim(read):E21: Cannot make changes' issue

### DIFF
--- a/autoload/template.vim
+++ b/autoload/template.vim
@@ -11,6 +11,10 @@ let s:loading_template = ''
 
 " Core functions. {{{1
 function! template#load(...)
+  if !&modifiable
+    return
+  endif
+
   let empty_buffer = line('$') == 1 && strlen(getline(1)) == 0
   let pattern = get(a:000, 0, 0)
   let lnum = get(a:000, 1, 0)


### PR DESCRIPTION
When unmodifiable buffer is re-opened, template#load() die with the following

```
Vim(read):E21: Cannot make changes, 'modifiable' is off:   silent keepalt :.-1 read `=tmpl`
```

This commit simply ignore templating process when the buffer is unmodifiable.
